### PR TITLE
add 'datasource' for InfluxdbTarget

### DIFF
--- a/grafanalib/influxdb.py
+++ b/grafanalib/influxdb.py
@@ -17,6 +17,7 @@ class InfluxDBTarget(object):
 
     :param alias: legend alias
     :param format: Bucket aggregators
+    :param datasource: InfluxDB name (Required if different influxb is used for different target) 
     :param measurement: Metric Aggregators
     :param query: query
     :param rawQuery: target reference id
@@ -25,6 +26,7 @@ class InfluxDBTarget(object):
 
     alias = attr.ib(default="")
     format = attr.ib(default=TIME_SERIES_TARGET_FORMAT)
+    datasource = attr.ib(default="")
     measurement = attr.ib(default="")
     query = attr.ib(default="")
     rawQuery = attr.ib(default=True)
@@ -34,6 +36,7 @@ class InfluxDBTarget(object):
         return {
             'query': self.query,
             'resultFormat': self.format,
+            'datasource': self.datasource,
             'alias': self.alias,
             'measurement': self.measurement,
             'rawQuery': self.rawQuery,


### PR DESCRIPTION
Under each InfluxdbTarget, a different data source can be specified. This allow the merging of trends from different influxb into the same Panel.

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Add a datasource for different InfluxdbTarget. Without this option, the InfluxdbTarget could only have one default datasource specify outside Target.  

## Why is it a good idea?
Different datasource for each Influxdbtarget allows the merging of different trend onto the same Panel.

## Context
The current setup using dataSource specify outside the target stencils. Adding a data source within the target allows a combination of different data sources on the same panel. This is carried out via adding "datasource" parameter within the influxdbTarget object similar to adding the parameters like query and measurement. This standalone datasource is supported by grafana.  

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
